### PR TITLE
Add missing class attribute to modal container

### DIFF
--- a/dist/stylekit.js
+++ b/dist/stylekit.js
@@ -186,6 +186,7 @@ function () {
 
       this.onElement = onElement;
       this.element = document.createElement('div');
+      this.element.className = 'sn-component';
       this.element.innerHTML = this.templateString().trim();
       document.addEventListener("keyup", this.keyupListener);
       this.buttons.forEach(function (buttonDesc, index) {

--- a/dist/stylekit.min.js
+++ b/dist/stylekit.min.js
@@ -186,6 +186,7 @@ function () {
 
       this.onElement = onElement;
       this.element = document.createElement('div');
+      this.element.className = 'sn-component';
       this.element.innerHTML = this.templateString().trim();
       document.addEventListener("keyup", this.keyupListener);
       this.buttons.forEach(function (buttonDesc, index) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-stylekit",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "main": "dist/dist.css",
   "scripts": {
     "build": "webpack"

--- a/src/js/Alert.js
+++ b/src/js/Alert.js
@@ -91,6 +91,7 @@ export default class SKAlert {
     this.onElement = onElement;
 
     this.element = document.createElement('div');
+    this.element.className = 'sn-component';
     this.element.innerHTML = this.templateString().trim();
 
     document.addEventListener("keyup", this.keyupListener);


### PR DESCRIPTION
When calling the `present` function, the modal is appended to the DOM, but it is missing the `sn-component` class attribute, resulting in the following:

![image](https://user-images.githubusercontent.com/5891646/69153426-977a7f00-0ab4-11ea-9706-d70750514bc3.png)
