### PR TITLE
fix: change submodule urls from git@ to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "themes/midnight"]
 	path = themes/midnight
-	url = git@github.com:sn-extensions/midnight-theme.git
+	url = https://github.com/sn-extensions/midnight-theme.git
 [submodule "themes/solarized-dark-theme"]
 	path = themes/solarized-dark-theme
-	url = git@github.com:sn-extensions/solarized-dark-theme.git
+	url = https://github.com/sn-extensions/solarized-dark-theme.git
 [submodule "themes/futura-theme"]
 	path = themes/futura-theme
-	url = git@github.com:sn-extensions/futura-theme.git
+	url = https://github.com/sn-extensions/futura-theme.git
 [submodule "themes/focus-theme"]
 	path = themes/focus-theme
-	url = git@github.com:sn-extensions/focus-theme.git
-	[submodule "themes/titanium-theme"]
-		path = themes/titanium-theme
-		url = git@github.com:sn-extensions/titanium-theme.git
+	url = https://github.com/sn-extensions/focus-theme.git
+[submodule "themes/titanium-theme"]
+	path = themes/titanium-theme
+	url = https://github.com/sn-extensions/titanium-theme.git


### PR DESCRIPTION
## Summary

This PR allows deploying the `master` branch to GitHub Pages like this: https://sn-extensions.github.io/StyleKit/

## Details

I tried to deploy GitHub Pages from `master` but I received an error:

![image](https://user-images.githubusercontent.com/22967798/107609503-f1082580-6bf3-11eb-90c4-7a75fb84d488.png)

So I changed the git urls from `git@` to `https://` and installed the submodules using the following command (as suggested on [GitHub's blog](https://github.blog/2016-02-01-working-with-submodules/)) to test that the urls worked:

```
git submodule update --init --recursive
```

Then I was able to deploy to GitHub Pages using the `gh-pages`:
![image](https://user-images.githubusercontent.com/22967798/107609663-768bd580-6bf4-11eb-88f4-f1e2b7121f33.png)

The result is that you can see how the StyleKit is used here: https://sn-extensions.github.io/StyleKit/

I think it's OK to use `https://` instead of `git@` because each theme's repository is public. Merging this PR would allow deploying to GitHub pages directly from the `master` branch. 🙂 