### PR TITLE
fix: remove border-left in ::webkit-scrollbar

### DIFF
--- a/dist/stylekit.css
+++ b/dist/stylekit.css
@@ -3100,7 +3100,7 @@ textarea,
 .linux-desktop ::-webkit-scrollbar {
   width: 17px;
   height: 18px;
-  border-left: 0.5px solid var(--sn-stylekit-scrollbar-track-border-color);
+  border-left: 0px;
 }
 
 .windows-web ::-webkit-scrollbar-thumb,

--- a/dist/stylekit.css
+++ b/dist/stylekit.css
@@ -3100,7 +3100,7 @@ textarea,
 .linux-desktop ::-webkit-scrollbar {
   width: 17px;
   height: 18px;
-  border-left: 0px;
+  border-left: none;
 }
 
 .windows-web ::-webkit-scrollbar-thumb,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-stylekit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/stylekit.js",
   "scripts": {
     "build": "webpack --mode='production'",

--- a/src/css/_scrollbar.scss
+++ b/src/css/_scrollbar.scss
@@ -7,7 +7,7 @@
   ::-webkit-scrollbar {
     width: 17px;
     height: 18px;
-    border-left: 0px;
+    border-left: none;
   }
 
   ::-webkit-scrollbar-thumb {

--- a/src/css/_scrollbar.scss
+++ b/src/css/_scrollbar.scss
@@ -7,7 +7,7 @@
   ::-webkit-scrollbar {
     width: 17px;
     height: 18px;
-    border-left: 0.5px solid var(--sn-stylekit-scrollbar-track-border-color);
+    border-left: 0px;
   }
 
   ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
hides scrollbar that was introduced in https://github.com/standardnotes/StyleKit/commit/41443fe9499c55690994136ca1115ed57735db4c

Before: 

![image](https://user-images.githubusercontent.com/22967798/109733623-535da180-7b74-11eb-963d-5dee5dacbb4d.png)


After: 

![image](https://user-images.githubusercontent.com/22967798/109733658-62dcea80-7b74-11eb-8abc-f7f04d5b7587.png)
